### PR TITLE
Add seasonal submission infrastructure for leagues and seasonal worlds

### DIFF
--- a/api/routes/webhook.py
+++ b/api/routes/webhook.py
@@ -46,28 +46,24 @@ def _normalize_submission_type(raw_submission_type):
             return normalized
 
 
-def _dispatch_non_main_submission(world_type, submission_type):
-    """Route non-main submissions by type (currently no-op handlers)."""
-    match world_type:
-        case "seasonal":
-            match submission_type:
-                case (
-                    "drop"
-                    | "collection_log"
-                    | "personal_best"
-                    | "combat_achievement"
-                    | "experience"
-                    | "quest"
-                    | "pet"
-                    | "adventure_log"
-                ):
-                    # Seasonal routing placeholder for future handlers.
-                    pass
-                case _:
-                    pass
+async def _dispatch_seasonal_submission(submission_type, processed_data, db_session):
+    """Route seasonal submissions to their respective processors with world_type='seasonal'."""
+    match submission_type:
+        case "drop" | "other" | "npc":
+            return await submissions.drop_processor(processed_data, external_session=db_session, world_type="seasonal")
+        case "collection_log":
+            return await submissions.clog_processor(processed_data, external_session=db_session, world_type="seasonal")
+        case "personal_best" | "kill_time" | "npc_kill":
+            return await submissions.pb_processor(processed_data, external_session=db_session, world_type="seasonal")
+        case "combat_achievement":
+            return await submissions.ca_processor(processed_data, external_session=db_session, world_type="seasonal")
+        case "pet":
+            return await submissions.pet_processor(processed_data, external_session=db_session, world_type="seasonal")
+        case "quest" | "quest_completion":
+            return await submissions.quest_processor(processed_data, external_session=db_session, world_type="seasonal")
         case _:
-            # Ignore all unsupported world types for now.
-            pass
+            # experience and adventure_log not yet tracked for seasonal worlds
+            return None
 
 
 async def _link_video_to_submission(processed_data, db_session):
@@ -225,11 +221,15 @@ async def _process_webhook_request(req_start):
                         world_type = _normalize_world_type(processed_data.get("world_type"))
                         processed_data["world_type"] = world_type
 
-                        if world_type != MAIN_WORLD_TYPE:
-                            _dispatch_non_main_submission(
-                                world_type,
+                        if world_type == "seasonal":
+                            response = await _dispatch_seasonal_submission(
                                 _normalize_submission_type(submission_type),
+                                processed_data,
+                                db_session,
                             )
+                            db_session.commit()
+                            continue
+                        elif world_type != MAIN_WORLD_TYPE:
                             continue
 
                         if image_file:

--- a/bots/webhook_bot.py
+++ b/bots/webhook_bot.py
@@ -73,28 +73,30 @@ def _normalize_submission_type(raw_submission_type):
             return normalized
 
 
-def _dispatch_non_main_submission(world_type, submission_type):
-    """Route non-main submissions by type (currently no-op handlers)."""
-    match world_type:
-        case "seasonal":
-            match submission_type:
-                case (
-                    "drop"
-                    | "collection_log"
-                    | "personal_best"
-                    | "combat_achievement"
-                    | "experience"
-                    | "quest"
-                    | "pet"
-                    | "adventure_log"
-                ):
-                    # Seasonal routing placeholder for future handlers.
-                    pass
-                case _:
-                    pass
+async def _dispatch_seasonal_submission(submission_type, embed_data, session):
+    """Route seasonal submissions to their respective processors with world_type='seasonal'."""
+    match submission_type:
+        case "drop":
+            from data.submissions import drop_processor
+            return await drop_processor(embed_data, external_session=session, world_type="seasonal")
+        case "collection_log":
+            from data.submissions import clog_processor
+            return await clog_processor(embed_data, external_session=session, world_type="seasonal")
+        case "personal_best":
+            from data.submissions import pb_processor
+            return await pb_processor(embed_data, external_session=session, world_type="seasonal")
+        case "combat_achievement":
+            from data.submissions import ca_processor
+            return await ca_processor(embed_data, external_session=session, world_type="seasonal")
+        case "pet":
+            from data.submissions import pet_processor
+            return await pet_processor(embed_data, external_session=session, world_type="seasonal")
+        case "quest":
+            from data.submissions import quest_processor
+            return await quest_processor(embed_data, external_session=session, world_type="seasonal")
         case _:
-            # Ignore unsupported world types for now.
-            pass
+            # experience and adventure_log not yet tracked for seasonal worlds
+            return None
 
 RETRYABLE_DB_ERROR_STRINGS = (
     "server has gone away",
@@ -260,8 +262,10 @@ async def process_submission_with_session(submission_type, embed_data):
     session = Session()
     try:
         success = False
-        if world_type != MAIN_WORLD_TYPE:
-            _dispatch_non_main_submission(world_type, normalized_submission_type)
+        if world_type == "seasonal":
+            result = await _dispatch_seasonal_submission(normalized_submission_type, embed_data, session)
+            success = True
+        elif world_type != MAIN_WORLD_TYPE:
             result = None
             success = True
         elif normalized_submission_type == "collection_log":

--- a/data/submissions/ca.py
+++ b/data/submissions/ca.py
@@ -14,14 +14,19 @@ from .common import (
     debug_print,
     GroupConfiguration,
     is_truthy_config,
+    get_config_prefix,
+    SEASONAL_WORLD_TYPE,
+    SeasonalCombatAchievementEntry,
 )
 
 
-async def ca_processor(ca_data, external_session=None):
-    debug_print(f"=== CA PROCESSOR START ===")
+async def ca_processor(ca_data, external_session=None, world_type="main"):
+    debug_print(f"=== CA PROCESSOR START (world_type={world_type}) ===")
     debug_print(f"Raw CA data: {ca_data}")
     debug_print(f"External session provided: {external_session is not None}")
 
+    config_prefix = get_config_prefix(world_type)
+    is_seasonal = world_type == SEASONAL_WORLD_TYPE
     has_xf_entry = False
     session, use_external_session = select_session_and_flag(external_session)
     debug_print(f"Using external session: {use_external_session}")
@@ -63,18 +68,20 @@ async def ca_processor(ca_data, external_session=None):
         debug_print("User failed auth check")
         return
 
-    if not await ensure_can_create(session, unique_id, "ca"):
+    dedup_type = "seasonal_ca" if is_seasonal else "ca"
+    if not await ensure_can_create(session, unique_id, dedup_type):
         debug_print(
             f"Combat Achievement entry with Unique ID {unique_id} already exists in the database, aborting"
         )
         return
     from db import CombatAchievementEntry
 
+    ca_model = SeasonalCombatAchievementEntry if is_seasonal else CombatAchievementEntry
     ca_entry = (
-        session.query(CombatAchievementEntry)
+        session.query(ca_model)
         .filter(
-            CombatAchievementEntry.player_id == player_id,
-            CombatAchievementEntry.task_name == task_name,
+            ca_model.player_id == player_id,
+            ca_model.task_name == task_name,
         )
         .first()
     )
@@ -86,7 +93,7 @@ async def ca_processor(ca_data, external_session=None):
             + str(tier)
         )
         dl_path = ""
-        ca_entry = CombatAchievementEntry(
+        ca_entry = ca_model(
             player_id=player_id,
             task_name=task_name,
             date_added=datetime.now(),
@@ -155,22 +162,23 @@ async def ca_processor(ca_data, external_session=None):
             ca_tier = "grandmaster_ca"
         case _:
             points = 1
-    try:
-        award_points_to_player(
-            player_id=player_id,
-            amount=points,
-            source=f"Combat Achievement: {task_name}",
-            expires_in_days=60,
-        )
-    except Exception as e:
-        debug_print(f"Couldn't award points to player: {e}")
-        from .common import app_logger
-        app_logger.log(
-            log_type="error",
-            data=f"Couldn't award points to player: {e}",
-            app_name="core",
-            description="ca_processor",
-        )
+    if not is_seasonal:
+        try:
+            award_points_to_player(
+                player_id=player_id,
+                amount=points,
+                source=f"Combat Achievement: {task_name}",
+                expires_in_days=60,
+            )
+        except Exception as e:
+            debug_print(f"Couldn't award points to player: {e}")
+            from .common import app_logger
+            app_logger.log(
+                log_type="error",
+                data=f"Couldn't award points to player: {e}",
+                app_name="core",
+                description="ca_processor",
+            )
     if is_new_ca:
         debug_print("New CA entry, creating notification")
         player_groups = get_player_groups_with_global(session, player)
@@ -183,28 +191,31 @@ async def ca_processor(ca_data, external_session=None):
                 "total_points_awarded": 0,
                 "awarded_members": [],
             }
-            # Group-specific point awards (custom points system)
-            try:
-                from .common import check_group_point_system_active
-                if check_group_point_system_active(group_id, session):
-                    from .point_awards import check_and_award_points
-                    group_points_result = await check_and_award_points(
-                        ca_tier,
-                        group_id,
-                        player_id,
-                        1,
-                        entry_id=getattr(ca_entry, "id", None),
-                        submission_timestamp=ca_data.get("timestamp"),
-                        external_session=session,
-                    )
-                    
-            except Exception as e:
-                print(f"Couldn't perform check against group point awards... e: {e}")
+            if is_seasonal:
+                # TODO: award group points for seasonal CAs once award_points_in_leagues
+                # config key is supported.
+                pass
+            else:
+                try:
+                    from .common import check_group_point_system_active
+                    if check_group_point_system_active(group_id, session):
+                        from .point_awards import check_and_award_points
+                        group_points_result = await check_and_award_points(
+                            ca_tier,
+                            group_id,
+                            player_id,
+                            1,
+                            entry_id=getattr(ca_entry, "id", None),
+                            submission_timestamp=ca_data.get("timestamp"),
+                            external_session=session,
+                        )
+                except Exception as e:
+                    print(f"Couldn't perform check against group point awards... e: {e}")
             ca_notify_config = (
                 session.query(GroupConfiguration)
                 .filter(
                     GroupConfiguration.group_id == group_id,
-                    GroupConfiguration.config_key == "notify_cas",
+                    GroupConfiguration.config_key == f"{config_prefix}notify_cas",
                 )
                 .first()
             )
@@ -218,7 +229,7 @@ async def ca_processor(ca_data, external_session=None):
                 min_tier = (
                     session.query(GroupConfiguration.config_value)
                     .filter(
-                        GroupConfiguration.config_key == "min_ca_tier_to_notify",
+                        GroupConfiguration.config_key == f"{config_prefix}min_ca_tier_to_notify",
                         GroupConfiguration.group_id == group_id,
                     )
                     .first()
@@ -256,6 +267,7 @@ async def ca_processor(ca_data, external_session=None):
                                 "group_points_receiver_total": int(group_points_result.get("receiver_current_points", 0)),
                                 "group_points_member_count": len(group_points_result.get("awarded_members", []) or []),
                                 "group_points_members_awarded": group_points_result.get("awarded_members", []) or [],
+                                "world_type": world_type,
                             }
                             if player and player.user:
                                 user = session.query(type(player.user)).filter(type(player.user).user_id == player.user_id).first()

--- a/data/submissions/clog.py
+++ b/data/submissions/clog.py
@@ -16,14 +16,19 @@ from .common import (
     debug_print,
     GroupConfiguration,
     award_points_to_player,
+    get_config_prefix,
+    SEASONAL_WORLD_TYPE,
+    SeasonalCollectionLogEntry,
 )
 
 
-async def clog_processor(clog_data, external_session=None):
-    debug_print(f"=== CLOG PROCESSOR START ===")
+async def clog_processor(clog_data, external_session=None, world_type="main"):
+    debug_print(f"=== CLOG PROCESSOR START (world_type={world_type}) ===")
     debug_print(f"Raw clog data: {clog_data}")
     debug_print(f"External session provided: {external_session is not None}")
 
+    config_prefix = get_config_prefix(world_type)
+    is_seasonal = world_type == SEASONAL_WORLD_TYPE
     debug_test = False
     player_name = clog_data.get("player_name", clog_data.get("player", None))
     if player_name == "joelhalen":
@@ -54,7 +59,8 @@ async def clog_processor(clog_data, external_session=None):
     notice = ""
     item = await ensure_item_by_name(session, item_name)
 
-    if not await ensure_can_create(session, unique_id, "clog"):
+    dedup_type = "seasonal_clog" if is_seasonal else "clog"
+    if not await ensure_can_create(session, unique_id, dedup_type):
         print(
             f"Collection Log entry with Unique ID {unique_id} already exists in the database, aborting"
         )
@@ -91,11 +97,12 @@ async def clog_processor(clog_data, external_session=None):
 
     from db import CollectionLogEntry, User, UserConfiguration
 
+    clog_model = SeasonalCollectionLogEntry if is_seasonal else CollectionLogEntry
     clog_entry = (
-        session.query(CollectionLogEntry)
+        session.query(clog_model)
         .filter(
-            CollectionLogEntry.player_id == player_id,
-            CollectionLogEntry.item_id == item_id,
+            clog_model.player_id == player_id,
+            clog_model.item_id == item_id,
         )
         .first()
     )
@@ -105,7 +112,7 @@ async def clog_processor(clog_data, external_session=None):
         print(f"We did not find an npc for {npc_name}, aborting")
         return
     if not clog_entry:
-        clog_entry = CollectionLogEntry(
+        clog_entry = clog_model(
             player_id=player_id,
             reported_slots=reported_slots,
             item_id=item_id,
@@ -156,12 +163,13 @@ async def clog_processor(clog_data, external_session=None):
 
     if is_new_clog:
         print("New collection log -- Creating notification")
-        award_points_to_player(
-            player_id=player_id,
-            amount=5,
-            source=f"Collection Log slot: {item_name}",
-            expires_in_days=60,
-        )
+        if not is_seasonal:
+            award_points_to_player(
+                player_id=player_id,
+                amount=5,
+                source=f"Collection Log slot: {item_name}",
+                expires_in_days=60,
+            )
         player_groups = get_player_groups_with_global(session, player)
         for group in player_groups:
             print(f"CLOG: Checking group: {group}")
@@ -172,32 +180,37 @@ async def clog_processor(clog_data, external_session=None):
                 "total_points_awarded": 0,
                 "awarded_members": [],
             }
-            async def perform_point_check():
-                nonlocal group_points_result
-                from .common import check_group_point_system_active
-                if check_group_point_system_active(group_id, session):
-                    from .point_awards import check_and_award_points
-                    group_points_result = await check_and_award_points(
-                        "clog",
-                        group_id,
-                        player_id,
-                        1,
-                        entry_id=getattr(clog_entry, "log_id", None),
-                        submission_timestamp=clog_data.get("timestamp"),
-                        external_session=session,
-                    )
-                else:
-                    pass # print("Group does not have custom point system active")
-            try:
-                await perform_point_check()
-            except Exception as e:
-                print(f"Couldn't perform check against group point awards... e: {e}")
+            if is_seasonal:
+                # TODO: award group points for seasonal collection log entries once
+                # award_points_in_leagues config key is supported.
                 pass
+            else:
+                async def perform_point_check():
+                    nonlocal group_points_result
+                    from .common import check_group_point_system_active
+                    if check_group_point_system_active(group_id, session):
+                        from .point_awards import check_and_award_points
+                        group_points_result = await check_and_award_points(
+                            "clog",
+                            group_id,
+                            player_id,
+                            1,
+                            entry_id=getattr(clog_entry, "log_id", None),
+                            submission_timestamp=clog_data.get("timestamp"),
+                            external_session=session,
+                        )
+                    else:
+                        pass
+                try:
+                    await perform_point_check()
+                except Exception as e:
+                    print(f"Couldn't perform check against group point awards... e: {e}")
+                    pass
             clog_notify_config = (
                 session.query(GroupConfiguration)
                 .filter(
                     GroupConfiguration.group_id == group_id,
-                    GroupConfiguration.config_key == "notify_clogs",
+                    GroupConfiguration.config_key == f"{config_prefix}notify_clogs",
                 )
                 .first()
             )
@@ -224,6 +237,7 @@ async def clog_processor(clog_data, external_session=None):
                     "group_points_receiver_total": int(group_points_result.get("receiver_current_points", 0)),
                     "group_points_member_count": len(group_points_result.get("awarded_members", []) or []),
                     "group_points_members_awarded": group_points_result.get("awarded_members", []) or [],
+                    "world_type": world_type,
                 }
                 await create_notification(
                     "clog",

--- a/data/submissions/common.py
+++ b/data/submissions/common.py
@@ -36,6 +36,12 @@ from db import (
     GroupConfiguration,
     UserConfiguration,
     NotificationQueue,
+    SeasonalDrop,
+    SeasonalPersonalBestEntry,
+    SeasonalCollectionLogEntry,
+    SeasonalCombatAchievementEntry,
+    SeasonalPlayerPet,
+    SeasonalQuestCompletionEntry,
 )
 from db.ops import DatabaseOperations, associate_player_ids, get_point_divisor
 from sqlalchemy import func, text
@@ -81,6 +87,30 @@ def debug_print(message, **kwargs):
     if debug:
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         print(f"[{timestamp}] DEBUG: {message}", **kwargs)
+
+
+SEASONAL_WORLD_TYPE = "seasonal"
+
+
+def get_config_prefix(world_type: str) -> str:
+    """Return the GroupConfiguration key prefix for the given world type.
+
+    Seasonal submissions use config keys prefixed with "seasonal_" so groups
+    can define separate channel IDs, limits, and enabled flags for each mode.
+    """
+    return "seasonal_" if world_type == SEASONAL_WORLD_TYPE else ""
+
+
+def get_seasonal_model(submission_type: str):
+    """Return the seasonal ORM model class for the given submission type string."""
+    return {
+        "drop": SeasonalDrop,
+        "personal_best": SeasonalPersonalBestEntry,
+        "collection_log": SeasonalCollectionLogEntry,
+        "combat_achievement": SeasonalCombatAchievementEntry,
+        "pet": SeasonalPlayerPet,
+        "quest": SeasonalQuestCompletionEntry,
+    }.get(submission_type)
 
 
 global_footer = os.getenv("DISCORD_MESSAGE_FOOTER")
@@ -598,6 +628,37 @@ async def ensure_can_create(session, unique_id, submission_type) -> bool:
                 return session.query(QuestCompletionEntry).filter(
                     QuestCompletionEntry.unique_id == unique_id,
                     QuestCompletionEntry.date_added > cutoff,
+                ).first()
+            case "seasonal_drop":
+                return session.query(SeasonalDrop).filter(
+                    SeasonalDrop.unique_id == unique_id,
+                    SeasonalDrop.used_api == True,
+                    SeasonalDrop.date_added > cutoff,
+                ).first()
+            case "seasonal_pb":
+                return session.query(SeasonalPersonalBestEntry).filter(
+                    SeasonalPersonalBestEntry.unique_id == unique_id,
+                    SeasonalPersonalBestEntry.date_added > cutoff,
+                ).first()
+            case "seasonal_clog":
+                return session.query(SeasonalCollectionLogEntry).filter(
+                    SeasonalCollectionLogEntry.unique_id == unique_id,
+                    SeasonalCollectionLogEntry.date_added > cutoff,
+                ).first()
+            case "seasonal_ca":
+                return session.query(SeasonalCombatAchievementEntry).filter(
+                    SeasonalCombatAchievementEntry.unique_id == unique_id,
+                    SeasonalCombatAchievementEntry.date_added > cutoff,
+                ).first()
+            case "seasonal_pet":
+                return session.query(SeasonalPlayerPet).filter(
+                    SeasonalPlayerPet.unique_id == unique_id,
+                    SeasonalPlayerPet.date_added > cutoff,
+                ).first()
+            case "seasonal_quest":
+                return session.query(SeasonalQuestCompletionEntry).filter(
+                    SeasonalQuestCompletionEntry.unique_id == unique_id,
+                    SeasonalQuestCompletionEntry.date_added > cutoff,
                 ).first()
         return None
     

--- a/data/submissions/drop.py
+++ b/data/submissions/drop.py
@@ -26,6 +26,9 @@ from .common import (
     award_points_to_player,
     player_list,
     redis_updates,
+    get_config_prefix,
+    SEASONAL_WORLD_TYPE,
+    SeasonalDrop,
 )
 
 
@@ -61,10 +64,10 @@ def _normalize_incoming_players(players_included):
     return None
 
 
-async def drop_processor(drop_data, external_session=None):
+async def drop_processor(drop_data, external_session=None, world_type="main"):
     """Process a drop submission and create notifications when appropriate."""
 
-    debug_print(f"=== DROP PROCESSOR START ===")
+    debug_print(f"=== DROP PROCESSOR START (world_type={world_type}) ===")
     debug_print(f"Raw drop data: {drop_data}")
     debug_print(f"External session provided: {external_session is not None}")
 
@@ -111,10 +114,14 @@ async def drop_processor(drop_data, external_session=None):
             f"normalized_type={type(players_included).__name__} normalized_value={players_included}"
         )
 
+        config_prefix = get_config_prefix(world_type)
+        is_seasonal = world_type == SEASONAL_WORLD_TYPE
+        dedup_type = "seasonal_drop" if is_seasonal else "drop"
+
         # dedupe via NotifiedSubmission cache in caller; keep local prevention via ensure_can_create
         from .common import ensure_can_create
 
-        if not await ensure_can_create(session, guid, "drop"):
+        if not await ensure_can_create(session, guid, dedup_type):
             return
 
         debug_print(
@@ -223,6 +230,7 @@ async def drop_processor(drop_data, external_session=None):
             used_api=used_api,
             unique_id=guid,
             existing_session=session if use_external_session else None,
+            model_class=SeasonalDrop if is_seasonal else None,
         )
         
 
@@ -235,7 +243,7 @@ async def drop_processor(drop_data, external_session=None):
         log_checkpoint("create_drop_object")
         try:
             debug_print("Updating player in redis...")
-            redis_updates.add_to_player(player, drop)
+            redis_updates.add_to_player(player, drop, world_type=world_type)
             debug_print("Player redis update completed")
         except Exception as e:
             debug_print(f"Error updating player in redis: {e}")
@@ -256,7 +264,10 @@ async def drop_processor(drop_data, external_session=None):
                 .filter(
                     GroupConfiguration.group_id.in_(group_ids),
                     GroupConfiguration.config_key.in_(
-                        ["minimum_value_to_notify", "send_stacks_of_items"]
+                        [
+                            f"{config_prefix}minimum_value_to_notify",
+                            f"{config_prefix}send_stacks_of_items",
+                        ]
                     ),
                 )
                 .all()
@@ -302,56 +313,62 @@ async def drop_processor(drop_data, external_session=None):
             # print(f"Processing group: {group.group_name} (ID: {group_id})")
             """ Here we can process the drop to determine if it needs to be calculated for a point award (group-specific points) """
 
-            async def perform_point_check():
-                nonlocal has_awarded_points, group_points_result
-                from .common import check_group_point_system_active
-                point_system_active = check_group_point_system_active(group_id, session)
-                debug_print(
-                    f"Group {group_id} point check start: active={point_system_active}, "
-                    f"players_included={players_included}, item_id={item_id}, npc_id={npc_id}, "
-                    f"value={int(drop.value) * int(drop.quantity)}, quantity={int(drop.quantity)}"
-                )
-                if point_system_active:
-                    from .point_awards import check_and_award_points
-                    group_points_result = await check_and_award_points(
-                        "drop",
-                        group_id,
-                        player_id,
-                        int(drop.value) * int(drop.quantity),
-                        players_included=players_included,
-                        item_id=item_id,
-                        npc_id=npc_id,
-                        quantity=int(drop.quantity),
-                        entry_id=getattr(drop, "drop_id", None),
-                        submission_guid=guid,
-                        submission_timestamp=drop_data.get("timestamp"),
-                        external_session=session,
-                    )
-                    debug_print(
-                        f"Group {group_id} point check result: receiver_points_awarded="
-                        f"{group_points_result.get('receiver_points_awarded', 0)} "
-                        f"receiver_current_points={group_points_result.get('receiver_current_points', 0)} "
-                        f"total_points_awarded={group_points_result.get('total_points_awarded', 0)} "
-                        f"awarded_members={group_points_result.get('awarded_members', [])}"
-                    )
-                    if int(group_points_result.get("total_points_awarded", 0)) > 0:
-                        has_awarded_points = True
-                else:
-                    pass # print("Group does not have custom point system active")
-
-            try:
-                await perform_point_check()
-            except Exception as e:
-                print(f"Couldn't perform check against group point awards... e: {e}")
+            if is_seasonal:
+                # TODO: award group points for seasonal drops once award_points_in_leagues
+                # config key is supported. Check group config for "award_points_in_leagues"
+                # before calling check_and_award_points with the seasonal entry_id.
                 pass
-            min_value_raw = group_config_values.get((group_id, "minimum_value_to_notify"))
+            else:
+                async def perform_point_check():
+                    nonlocal has_awarded_points, group_points_result
+                    from .common import check_group_point_system_active
+                    point_system_active = check_group_point_system_active(group_id, session)
+                    debug_print(
+                        f"Group {group_id} point check start: active={point_system_active}, "
+                        f"players_included={players_included}, item_id={item_id}, npc_id={npc_id}, "
+                        f"value={int(drop.value) * int(drop.quantity)}, quantity={int(drop.quantity)}"
+                    )
+                    if point_system_active:
+                        from .point_awards import check_and_award_points
+                        group_points_result = await check_and_award_points(
+                            "drop",
+                            group_id,
+                            player_id,
+                            int(drop.value) * int(drop.quantity),
+                            players_included=players_included,
+                            item_id=item_id,
+                            npc_id=npc_id,
+                            quantity=int(drop.quantity),
+                            entry_id=getattr(drop, "drop_id", None),
+                            submission_guid=guid,
+                            submission_timestamp=drop_data.get("timestamp"),
+                            external_session=session,
+                        )
+                        debug_print(
+                            f"Group {group_id} point check result: receiver_points_awarded="
+                            f"{group_points_result.get('receiver_points_awarded', 0)} "
+                            f"receiver_current_points={group_points_result.get('receiver_current_points', 0)} "
+                            f"total_points_awarded={group_points_result.get('total_points_awarded', 0)} "
+                            f"awarded_members={group_points_result.get('awarded_members', [])}"
+                        )
+                        if int(group_points_result.get("total_points_awarded", 0)) > 0:
+                            has_awarded_points = True
+                    else:
+                        pass # print("Group does not have custom point system active")
+
+                try:
+                    await perform_point_check()
+                except Exception as e:
+                    print(f"Couldn't perform check against group point awards... e: {e}")
+                    pass
+            min_value_raw = group_config_values.get((group_id, f"{config_prefix}minimum_value_to_notify"))
             try:
                 min_value_to_notify = int(min_value_raw) if min_value_raw is not None else 2500000
             except (TypeError, ValueError):
                 min_value_to_notify = 2500000
             debug_print(f"Group {group_id} minimum value to notify: {min_value_to_notify}")
 
-            send_stacks_value = group_config_values.get((group_id, "send_stacks_of_items"))
+            send_stacks_value = group_config_values.get((group_id, f"{config_prefix}send_stacks_of_items"))
             send_stacks = str(send_stacks_value).lower() in ("1", "true") if send_stacks_value is not None else False
             debug_print(
                 f"Group {group_id} config snapshot: minimum_value_to_notify_raw={min_value_raw}, "
@@ -376,20 +393,21 @@ async def drop_processor(drop_data, external_session=None):
                         continue ## Skipping this group in the loop; as there is no image despite the group's requirement of one
 
                 debug_print(f"Notification criteria met for group {group_id}")
-                point_divisor = get_point_divisor()
-                if group_id != 2 and has_awarded_points == False and int(drop_value) > point_divisor:
-                    print(
-                        f"Awarding points to {player_name} for drop {item_name} from {npc_name}"
-                    )
-                    has_awarded_points = True
-                    points_to_award = int(drop_value / point_divisor)
-                    # Global points award (not group-scoped)
-                    award_points_to_player(
-                        player_id=player_id,
-                        amount=points_to_award,
-                        source=f"Drop: {item_name} from {npc_name}",
-                        expires_in_days=60,
-                    )
+                if not is_seasonal:
+                    point_divisor = get_point_divisor()
+                    if group_id != 2 and has_awarded_points == False and int(drop_value) > point_divisor:
+                        print(
+                            f"Awarding points to {player_name} for drop {item_name} from {npc_name}"
+                        )
+                        has_awarded_points = True
+                        points_to_award = int(drop_value / point_divisor)
+                        # Global points award (not group-scoped)
+                        award_points_to_player(
+                            player_id=player_id,
+                            amount=points_to_award,
+                            source=f"Drop: {item_name} from {npc_name}",
+                            expires_in_days=60,
+                        )
                 notification_data = {
                     "drop_id": drop.drop_id,
                     "guid": guid,
@@ -410,6 +428,7 @@ async def drop_processor(drop_data, external_session=None):
                     "group_points_receiver_total": int(group_points_result.get("receiver_current_points", 0)),
                     "group_points_member_count": len(awarded_members),
                     "group_points_members_awarded": awarded_members,
+                    "world_type": world_type,
                 }
                 if group_id > 2:
                     sent_group_notifications.append(group.group_name)

--- a/data/submissions/pb.py
+++ b/data/submissions/pb.py
@@ -19,16 +19,21 @@ from .common import (
     debug_print,
     GroupConfiguration,
     is_truthy_config,
+    get_config_prefix,
+    SEASONAL_WORLD_TYPE,
+    SeasonalPersonalBestEntry,
 )
 
 
-async def pb_processor(pb_data, external_session=None):
-    debug_print(f"=== PB PROCESSOR START ===")
+async def pb_processor(pb_data, external_session=None, world_type="main"):
+    debug_print(f"=== PB PROCESSOR START (world_type={world_type}) ===")
     debug_print(f"Raw PB data: {pb_data}")
     debug_print(f"External session provided: {external_session is not None}")
 
     session, use_external_session = select_session_and_flag(external_session)
     debug_print(f"Using external session: {use_external_session}")
+    config_prefix = get_config_prefix(world_type)
+    is_seasonal = world_type == SEASONAL_WORLD_TYPE
     player_name = pb_data["player_name"]
     account_hash = pb_data["acc_hash"]
     boss_name = pb_data.get("npc_name", pb_data.get("boss_name", None))
@@ -56,7 +61,8 @@ async def pb_processor(pb_data, external_session=None):
 
     notice = ""
 
-    if not await ensure_can_create(session, unique_id, "pb"):
+    dedup_type = "seasonal_pb" if is_seasonal else "pb"
+    if not await ensure_can_create(session, unique_id, dedup_type):
         debug_print(
             f"Personal Best entry with Unique ID {unique_id} already exists in the database, aborting"
         )
@@ -80,12 +86,13 @@ async def pb_processor(pb_data, external_session=None):
         return
     from db import PersonalBestEntry
 
+    pb_model = SeasonalPersonalBestEntry if is_seasonal else PersonalBestEntry
     pb_entry = (
-        session.query(PersonalBestEntry)
+        session.query(pb_model)
         .filter(
-            PersonalBestEntry.player_id == player_id,
-            PersonalBestEntry.npc_id == npc_id,
-            PersonalBestEntry.team_size == team_size,
+            pb_model.player_id == player_id,
+            pb_model.npc_id == npc_id,
+            pb_model.team_size == team_size,
         )
         .first()
     )
@@ -134,7 +141,7 @@ async def pb_processor(pb_data, external_session=None):
         else:
             is_personal_best = False
     else:
-        pb_entry = PersonalBestEntry(
+        pb_entry = pb_model(
             player_id=player_id,
             npc_id=npc_id,
             team_size=team_size,
@@ -162,7 +169,7 @@ async def pb_processor(pb_data, external_session=None):
                 session.query(GroupConfiguration)
                 .filter(
                     GroupConfiguration.group_id.in_(group_ids),
-                    GroupConfiguration.config_key == "notify_pbs",
+                    GroupConfiguration.config_key == f"{config_prefix}notify_pbs",
                 )
                 .all()
             )
@@ -179,27 +186,33 @@ async def pb_processor(pb_data, external_session=None):
                 "total_points_awarded": 0,
                 "awarded_members": [],
             }
-            async def perform_point_check():
-                nonlocal group_points_result
-                from .common import check_group_point_system_active
-                if check_group_point_system_active(group_id, session):
-                    from .point_awards import check_and_award_points
-                    group_points_result = await check_and_award_points(
-                        "pb",
-                        group_id,
-                        player_id,
-                        1,
-                        entry_id=getattr(pb_entry, "id", None),
-                        submission_timestamp=pb_data.get("timestamp"),
-                        external_session=session,
-                    )
-                else:
-                    pass # print("Group does not have custom point system active")
-            try:
-                await perform_point_check()
-            except Exception as e:
-                print(f"Couldn't perform check against group point awards... e: {e}")
+            if is_seasonal:
+                # TODO: award group points for seasonal PBs once award_points_in_leagues
+                # config key is supported. Check group config for "award_points_in_leagues"
+                # before calling check_and_award_points with the seasonal entry_id.
                 pass
+            else:
+                async def perform_point_check():
+                    nonlocal group_points_result
+                    from .common import check_group_point_system_active
+                    if check_group_point_system_active(group_id, session):
+                        from .point_awards import check_and_award_points
+                        group_points_result = await check_and_award_points(
+                            "pb",
+                            group_id,
+                            player_id,
+                            1,
+                            entry_id=getattr(pb_entry, "id", None),
+                            submission_timestamp=pb_data.get("timestamp"),
+                            external_session=session,
+                        )
+                    else:
+                        pass
+                try:
+                    await perform_point_check()
+                except Exception as e:
+                    print(f"Couldn't perform check against group point awards... e: {e}")
+                    pass
             if pb_notify_config and is_truthy_config(getattr(pb_notify_config, "config_value", None)):
                 if (await screenshot_required(session, group_id)):
                     # Treat video submissions as satisfying screenshot requirement
@@ -224,6 +237,7 @@ async def pb_processor(pb_data, external_session=None):
                     "group_points_receiver_total": int(group_points_result.get("receiver_current_points", 0)),
                     "group_points_member_count": len(group_points_result.get("awarded_members", []) or []),
                     "group_points_members_awarded": group_points_result.get("awarded_members", []) or [],
+                    "world_type": world_type,
                 }
                 await create_notification(
                     "pb",

--- a/data/submissions/pet.py
+++ b/data/submissions/pet.py
@@ -17,14 +17,19 @@ from .common import (
     debug_print,
     GroupConfiguration,
     award_points_to_player,
+    get_config_prefix,
+    SEASONAL_WORLD_TYPE,
+    SeasonalPlayerPet,
 )
 
 
-async def pet_processor(pet_data, external_session=None):
-    debug_print(f"=== PET PROCESSOR START ===")
+async def pet_processor(pet_data, external_session=None, world_type="main"):
+    debug_print(f"=== PET PROCESSOR START (world_type={world_type}) ===")
     debug_print(f"Raw pet data: {pet_data}")
     debug_print(f"External session provided: {external_session is not None}")
 
+    config_prefix = get_config_prefix(world_type)
+    is_seasonal = world_type == SEASONAL_WORLD_TYPE
     session, use_external_session = select_session_and_flag(external_session)
     debug_print(f"Using external session: {use_external_session}")
 
@@ -56,7 +61,8 @@ async def pet_processor(pet_data, external_session=None):
     unique_id = pet_data.get("guid", None)
     video_key = pet_data.get("video_key")
     notice = ""
-    if not await ensure_can_create(session, unique_id, "pet"):
+    dedup_type = "seasonal_pet" if is_seasonal else "pet"
+    if not await ensure_can_create(session, unique_id, dedup_type):
         print(
             f"Pet entry with Unique ID {unique_id} already exists in the database, aborting"
         )
@@ -96,12 +102,13 @@ async def pet_processor(pet_data, external_session=None):
 
     from db import PlayerPet, User
 
+    pet_model = SeasonalPlayerPet if is_seasonal else PlayerPet
     existing_pet = None
     new_pet = None
     if pet_item_id:
         existing_pet = (
-            session.query(PlayerPet)
-            .filter(PlayerPet.player_id == player_id, PlayerPet.item_id == pet_item_id)
+            session.query(pet_model)
+            .filter(pet_model.player_id == player_id, pet_model.item_id == pet_item_id)
             .first()
         )
 
@@ -110,7 +117,7 @@ async def pet_processor(pet_data, external_session=None):
     if is_new_pet and pet_item_id:
         debug_print(f"Creating new pet entry for {player_name}: {pet_name}")
         try:
-            new_pet = PlayerPet(player_id=player_id, item_id=pet_item_id, pet_name=pet_name, unique_id=unique_id, date_added=datetime.now())
+            new_pet = pet_model(player_id=player_id, item_id=pet_item_id, pet_name=pet_name, unique_id=unique_id, date_added=datetime.now())
             session.add(new_pet)
             session.commit()
             debug_print(f"Pet entry created successfully")
@@ -150,7 +157,7 @@ async def pet_processor(pet_data, external_session=None):
             )
     elif downloaded:
         dl_path = image_url
-    if is_new_pet:
+    if is_new_pet and not is_seasonal:
         award_points_to_player(
             player_id=player_id, amount=50, source=f"Pet: {pet_name}", expires_in_days=60
         )
@@ -166,7 +173,7 @@ async def pet_processor(pet_data, external_session=None):
                 session.query(GroupConfiguration)
                 .filter(
                     GroupConfiguration.group_id == group_id,
-                    GroupConfiguration.config_key == "notify_pets",
+                    GroupConfiguration.config_key == f"{config_prefix}notify_pets",
                 )
                 .first()
             )
@@ -176,33 +183,38 @@ async def pet_processor(pet_data, external_session=None):
                 "total_points_awarded": 0,
                 "awarded_members": [],
             }
-            async def perform_point_check():
-                nonlocal group_points_result
-                from .common import check_group_point_system_active
-                if check_group_point_system_active(group_id, session):
-                    from .point_awards import check_and_award_points
-                    pet_entry_id = None
-                    if new_pet is not None:
-                        pet_entry_id = getattr(new_pet, "id", None)
-                    elif existing_pet is not None:
-                        pet_entry_id = getattr(existing_pet, "id", None)
-
-                    group_points_result = await check_and_award_points(
-                        "pet",
-                        group_id,
-                        player_id,
-                        1,
-                        entry_id=pet_entry_id,
-                        submission_timestamp=pet_data.get("timestamp"),
-                        external_session=session,
-                    )
-                else:
-                    pass # print("Group does not have custom point system active")
-            try:
-                await perform_point_check()
-            except Exception as e:
-                print(f"Couldn't perform check against group point awards... e: {e}")
+            if is_seasonal:
+                # TODO: award group points for seasonal pets once award_points_in_leagues
+                # config key is supported.
                 pass
+            else:
+                async def perform_point_check():
+                    nonlocal group_points_result
+                    from .common import check_group_point_system_active
+                    if check_group_point_system_active(group_id, session):
+                        from .point_awards import check_and_award_points
+                        pet_entry_id = None
+                        if new_pet is not None:
+                            pet_entry_id = getattr(new_pet, "id", None)
+                        elif existing_pet is not None:
+                            pet_entry_id = getattr(existing_pet, "id", None)
+
+                        group_points_result = await check_and_award_points(
+                            "pet",
+                            group_id,
+                            player_id,
+                            1,
+                            entry_id=pet_entry_id,
+                            submission_timestamp=pet_data.get("timestamp"),
+                            external_session=session,
+                        )
+                    else:
+                        pass
+                try:
+                    await perform_point_check()
+                except Exception as e:
+                    print(f"Couldn't perform check against group point awards... e: {e}")
+                    pass
             debug_print(
                 f"Pet notify config for group {group_id}: {pet_notify_config.config_value if pet_notify_config else 'None'}"
             )
@@ -236,6 +248,7 @@ async def pet_processor(pet_data, external_session=None):
                     "group_points_receiver_total": int(group_points_result.get("receiver_current_points", 0)),
                     "group_points_member_count": len(awarded_members),
                     "group_points_members_awarded": awarded_members,
+                    "world_type": world_type,
                 }
                 if player and player.user:
                     user = session.query(User).filter(User.user_id == player.user_id).first()

--- a/data/submissions/quest.py
+++ b/data/submissions/quest.py
@@ -17,6 +17,9 @@ from .common import (
     ensure_can_create,
     debug_print,
     GroupConfiguration,
+    get_config_prefix,
+    SEASONAL_WORLD_TYPE,
+    SeasonalQuestCompletionEntry,
 )
 
 
@@ -29,7 +32,7 @@ def _safe_int(value):
         return None
 
 
-async def quest_processor(quest_data, external_session=None):
+async def quest_processor(quest_data, external_session=None, world_type="main"):
     """
     Process quest completion submissions.
 
@@ -44,9 +47,11 @@ async def quest_processor(quest_data, external_session=None):
       - image_url / image_path (optional)
       - video_key / video_url (optional; supported for consistency)
     """
-    print("=== QUEST PROCESSOR START ===")
+    print(f"=== QUEST PROCESSOR START (world_type={world_type}) ===")
     print(f"[QUEST] Raw quest data: {quest_data}")
 
+    config_prefix = get_config_prefix(world_type)
+    is_seasonal = world_type == SEASONAL_WORLD_TYPE
     session, use_external_session = select_session_and_flag(external_session)
 
     player_name = quest_data.get("player_name") or quest_data.get("player")
@@ -82,7 +87,8 @@ async def quest_processor(quest_data, external_session=None):
         return SubmissionResponse(success=False, message="Missing player_name or acc_hash.")
     if not quest_name:
         return SubmissionResponse(success=False, message="Missing quest_name.")
-    if unique_id and not await ensure_can_create(session, unique_id, "quest"):
+    dedup_type = "seasonal_quest" if is_seasonal else "quest"
+    if unique_id and not await ensure_can_create(session, unique_id, dedup_type):
         return SubmissionResponse(success=True, message="Quest already processed (duplicate guid).")
 
     # Authenticate player
@@ -95,7 +101,8 @@ async def quest_processor(quest_data, external_session=None):
         return SubmissionResponse(success=False, message="Player authentication failed.")
 
     player_id = player.player_id
-    quest_entry = QuestCompletionEntry(
+    quest_model = SeasonalQuestCompletionEntry if is_seasonal else QuestCompletionEntry
+    quest_entry = quest_model(
         player_id=player_id,
         quest_name=quest_name,
         quests_completed=_safe_int(quests_completed),
@@ -132,7 +139,7 @@ async def quest_processor(quest_data, external_session=None):
             session.query(GroupConfiguration)
             .filter(
                 GroupConfiguration.group_id == group_id,
-                GroupConfiguration.config_key == "notify_quests",
+                GroupConfiguration.config_key == f"{config_prefix}notify_quests",
             )
             .first()
         )
@@ -169,6 +176,7 @@ async def quest_processor(quest_data, external_session=None):
             "image_url": image_url or "",
             "video_key": video_key,
             "video_url": video_url,
+            "world_type": world_type,
         }
         print(f"Notification data: {notification_data}")
 

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -41,6 +41,12 @@ from .premium_features import (
 from .tickets import Ticket
 from .group_points import PlayerPoints, GroupPointConfig, GroupPointMods, GroupPointTimedEvent, GroupPointBlacklist
 from .video_upload import VideoUpload
+from .seasonal_drop import SeasonalDrop
+from .seasonal_personal_best import SeasonalPersonalBestEntry
+from .seasonal_collection_log import SeasonalCollectionLogEntry
+from .seasonal_combat_achievement import SeasonalCombatAchievementEntry
+from .seasonal_pet import SeasonalPlayerPet
+from .seasonal_quest_completion import SeasonalQuestCompletionEntry
 
 
 def get_current_partition() -> int:
@@ -108,4 +114,10 @@ __all__ = [
     "GroupPointTimedEvent",
     "GroupPointBlacklist",
     "VideoUpload",
+    "SeasonalDrop",
+    "SeasonalPersonalBestEntry",
+    "SeasonalCollectionLogEntry",
+    "SeasonalCombatAchievementEntry",
+    "SeasonalPlayerPet",
+    "SeasonalQuestCompletionEntry",
 ]

--- a/db/models/seasonal_collection_log.py
+++ b/db/models/seasonal_collection_log.py
@@ -1,0 +1,21 @@
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey
+from sqlalchemy import func
+
+from .base import Base
+
+
+class SeasonalCollectionLogEntry(Base):
+    __tablename__ = 'seasonal_collection'
+    __table_args__ = {'extend_existing': True}
+
+    log_id = Column(Integer, primary_key=True, autoincrement=True)
+    item_id = Column(Integer, index=True, nullable=False)
+    npc_id = Column(Integer, ForeignKey('npc_list.npc_id'), nullable=False)
+    player_id = Column(Integer, ForeignKey('players.player_id'), index=True, nullable=False)
+    reported_slots = Column(Integer)
+    image_url = Column(String(300), nullable=True)
+    video_url = Column(String(500), nullable=True)
+    date_added = Column(DateTime, index=True, default=func.now())
+    date_updated = Column(DateTime, onupdate=func.now(), default=func.now())
+    used_api = Column(Boolean, default=False)
+    unique_id = Column(String(255), nullable=True)

--- a/db/models/seasonal_combat_achievement.py
+++ b/db/models/seasonal_combat_achievement.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey
+from sqlalchemy import func
+
+from .base import Base
+
+
+class SeasonalCombatAchievementEntry(Base):
+    __tablename__ = 'seasonal_combat_achievement'
+    __table_args__ = {'extend_existing': True}
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    player_id = Column(Integer, ForeignKey('players.player_id'))
+    task_name = Column(String(255), nullable=False)
+    image_url = Column(String(300), nullable=True)
+    video_url = Column(String(500), nullable=True)
+    date_added = Column(DateTime, index=True, default=func.now())
+    used_api = Column(Boolean, default=False)
+    unique_id = Column(String(255), nullable=True)

--- a/db/models/seasonal_drop.py
+++ b/db/models/seasonal_drop.py
@@ -1,0 +1,26 @@
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey
+from sqlalchemy import func
+
+from .base import Base
+from .drop import get_current_partition
+
+
+class SeasonalDrop(Base):
+    __tablename__ = 'seasonal_drops'
+    __table_args__ = {'extend_existing': True}
+
+    drop_id = Column(Integer, primary_key=True, autoincrement=True)
+    item_id = Column(Integer, ForeignKey('items.item_id'), index=True)
+    player_id = Column(Integer, ForeignKey('players.player_id'), index=True, nullable=False)
+    date_added = Column(DateTime, index=True, default=func.now())
+    npc_id = Column(Integer, ForeignKey('npc_list.npc_id'), index=True)
+    date_updated = Column(DateTime, onupdate=func.now(), default=func.now())
+    value = Column(Integer)
+    quantity = Column(Integer)
+    image_url = Column(String(300), nullable=True)
+    video_url = Column(String(500), nullable=True)
+    authed = Column(Boolean, default=False)
+    used_api = Column(Boolean, default=False)
+    hidden = Column(Boolean, default=False, nullable=False, server_default="0")
+    partition = Column(Integer, default=get_current_partition, index=True)
+    unique_id = Column(String(255), nullable=True)

--- a/db/models/seasonal_personal_best.py
+++ b/db/models/seasonal_personal_best.py
@@ -1,0 +1,22 @@
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey
+from sqlalchemy import func
+
+from .base import Base
+
+
+class SeasonalPersonalBestEntry(Base):
+    __tablename__ = 'seasonal_personal_best'
+    __table_args__ = {'extend_existing': True}
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    player_id = Column(Integer, ForeignKey('players.player_id'))
+    npc_id = Column(Integer, ForeignKey('npc_list.npc_id'))
+    kill_time = Column(Integer, nullable=False)
+    personal_best = Column(Integer, nullable=False)
+    team_size = Column(String(15), nullable=False, default="Solo")
+    new_pb = Column(Boolean, default=False)
+    image_url = Column(String(300), nullable=True)
+    video_url = Column(String(500), nullable=True)
+    date_added = Column(DateTime, nullable=True, default=func.now())
+    used_api = Column(Boolean, default=False)
+    unique_id = Column(String(255), nullable=True)

--- a/db/models/seasonal_pet.py
+++ b/db/models/seasonal_pet.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime
+
+from .base import Base
+
+
+class SeasonalPlayerPet(Base):
+    __tablename__ = 'seasonal_player_pets'
+    __table_args__ = {'extend_existing': True}
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    player_id = Column(Integer, ForeignKey('players.player_id'))
+    item_id = Column(Integer, ForeignKey('items.item_id'))
+    date_added = Column(DateTime, nullable=True)
+    unique_id = Column(String(255), nullable=True)
+    pet_name = Column(String(255), nullable=False)

--- a/db/models/seasonal_quest_completion.py
+++ b/db/models/seasonal_quest_completion.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey
+from sqlalchemy import func
+
+from .base import Base
+
+
+class SeasonalQuestCompletionEntry(Base):
+    __tablename__ = 'seasonal_quest_completions'
+    __table_args__ = {'extend_existing': True}
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    player_id = Column(Integer, ForeignKey('players.player_id'), index=True, nullable=False)
+    quest_name = Column(String(255), nullable=False)
+    quests_completed = Column(Integer, nullable=True)
+    total_quests = Column(Integer, nullable=True)
+    completion_percentage = Column(String(20), nullable=True)
+    quest_points = Column(Integer, nullable=True)
+    total_quest_points = Column(Integer, nullable=True)
+    qp_percentage = Column(String(20), nullable=True)
+    timestamp = Column(Integer, nullable=True)
+    image_url = Column(String(300), nullable=True)
+    video_url = Column(String(500), nullable=True)
+    date_added = Column(DateTime, index=True, default=func.now())
+    used_api = Column(Boolean, default=False)
+    unique_id = Column(String(255), nullable=True, unique=True, index=True)

--- a/db/ops.py
+++ b/db/ops.py
@@ -90,7 +90,7 @@ class DatabaseOperations:
         pass
 
     async def create_drop_object(self, item_id, player_id, date_received, npc_id, value, quantity, image_url: str = "", authed: bool = False,
-                                attachment_url: str = "", attachment_type: str = "", add_to_queue: bool = True, used_api: bool = False, unique_id: str = None, existing_session=None):
+                                attachment_url: str = "", attachment_type: str = "", add_to_queue: bool = True, used_api: bool = False, unique_id: str = None, existing_session=None, model_class=None):
         """
         Create a drop object and optionally add it to the processing queue.
         
@@ -169,8 +169,9 @@ class DatabaseOperations:
             image_url = image_url or ""
         # Initialize image URL with the provided one
 
-        # Create the drop object
-        newdrop = Drop(item_id=item_id,
+        # Create the drop object using the provided model class (default: Drop)
+        drop_model = model_class if model_class is not None else Drop
+        newdrop = drop_model(item_id=item_id,
                     player_id=player_id,
                     date_added=date_received_value,
                     date_updated=date_received_value,

--- a/services/redis_updates.py
+++ b/services/redis_updates.py
@@ -78,31 +78,37 @@ class RedisLootTracker:
                     continue
         return datetime.now()
     
-    def _get_redis_keys(self, player_id: int, partition: int, drop_date: datetime = None) -> Dict[str, str]:
-        """Generate Redis keys for a player and partition"""
+    def _get_redis_keys(self, player_id: int, partition: int, drop_date: datetime = None, world_type: str = "main") -> Dict[str, str]:
+        """Generate Redis keys for a player and partition.
+
+        Seasonal submissions are stored under a separate key namespace
+        (``seasonal:player:...``) to keep them completely isolated from
+        main-world data.
+        """
+        ns = "seasonal:player" if world_type == "seasonal" else "player"
         base_keys = {
-            'total_items': f"player:{player_id}:{partition}:total_items",
-            'total_loot': f"player:{player_id}:{partition}:total_loot",
-            'recent_items': f"player:{player_id}:{partition}:recent_items",
-            'drop_history': f"player:{player_id}:{partition}:drop_history",
-            'high_value_items': f"player:{player_id}:{partition}:high_value_items",
-            'all_time_total_items': f"player:{player_id}:all:total_items",
-            'all_time_total_loot': f"player:{player_id}:all:total_loot",
-            'all_time_recent_items': f"player:{player_id}:all:recent_items",
-            'all_time_high_value_items': f"player:{player_id}:all:high_value_items"
+            'total_items': f"{ns}:{player_id}:{partition}:total_items",
+            'total_loot': f"{ns}:{player_id}:{partition}:total_loot",
+            'recent_items': f"{ns}:{player_id}:{partition}:recent_items",
+            'drop_history': f"{ns}:{player_id}:{partition}:drop_history",
+            'high_value_items': f"{ns}:{player_id}:{partition}:high_value_items",
+            'all_time_total_items': f"{ns}:{player_id}:all:total_items",
+            'all_time_total_loot': f"{ns}:{player_id}:all:total_loot",
+            'all_time_recent_items': f"{ns}:{player_id}:all:recent_items",
+            'all_time_high_value_items': f"{ns}:{player_id}:all:high_value_items"
         }
-        
+
         # Add daily keys if drop_date is provided
         if drop_date:
             daily_partition = drop_date.strftime('%Y%m%d')  # YYYYMMDD format
             base_keys.update({
-                'daily_total_items': f"player:{player_id}:daily:{daily_partition}:total_items",
-                'daily_total_loot': f"player:{player_id}:daily:{daily_partition}:total_loot",
-                'daily_recent_items': f"player:{player_id}:daily:{daily_partition}:recent_items",
-                'daily_drop_history': f"player:{player_id}:daily:{daily_partition}:drop_history",
-                'daily_high_value_items': f"player:{player_id}:daily:{daily_partition}:high_value_items"
+                'daily_total_items': f"{ns}:{player_id}:daily:{daily_partition}:total_items",
+                'daily_total_loot': f"{ns}:{player_id}:daily:{daily_partition}:total_loot",
+                'daily_recent_items': f"{ns}:{player_id}:daily:{daily_partition}:recent_items",
+                'daily_drop_history': f"{ns}:{player_id}:daily:{daily_partition}:drop_history",
+                'daily_high_value_items': f"{ns}:{player_id}:daily:{daily_partition}:high_value_items"
             })
-        
+
         return base_keys
     
     def _atomic_hash_update_script(self) -> str:
@@ -158,62 +164,70 @@ class RedisLootTracker:
         return result
         """
     
-    def add_to_player(self, player: Player, drop: Drop) -> bool:
+    def add_to_player(self, player: Player, drop, world_type: str = "main") -> bool:
         """
         Add a single drop to a player's Redis cache (incremental update).
         Thread-safe and atomic. Also updates leaderboards.
+
+        Pass ``world_type="seasonal"`` to write into the seasonal key namespace
+        so that seasonal and main-world data are stored completely separately.
         """
         with self._lock:
             if player.player_id in self._processing_players:
                 # Player is being force-updated, skip incremental update
                 return False
-            
+
             try:
-                result = self._add_drop_incremental(player.player_id, drop)
+                result = self._add_drop_incremental(player.player_id, drop, world_type=world_type)
                 if result:
                     # Update leaderboards after successful drop addition
                     partition = self._get_partition(drop.date_added)
                     total_value = drop.value * drop.quantity
-                    
+
                     # Get player's group IDs for group leaderboards
                     player_group_ids = [group.group_id for group in player.groups] if player.groups else []
-                    
+
                     # Update leaderboards incrementally using ZINCRBY instead of full recalculation
-                    self._increment_leaderboards(player.player_id, total_value, partition, player_group_ids)
-                
+                    self._increment_leaderboards(player.player_id, total_value, partition, player_group_ids, world_type=world_type)
+
                 return result
             except Exception as e:
-                print(f"Error adding drop {drop.drop_id} to player {player.player_id}: {e}")
+                print(f"Error adding drop {getattr(drop, 'drop_id', '?')} to player {player.player_id}: {e}")
                 return False
     
-    def _increment_leaderboards(self, player_id: int, value_delta: int, 
-                                partition: Optional[int] = None, group_ids: Optional[List[int]] = None):
+    def _increment_leaderboards(self, player_id: int, value_delta: int,
+                                partition: Optional[int] = None, group_ids: Optional[List[int]] = None,
+                                world_type: str = "main"):
         """
         Incrementally update leaderboards by adding value_delta to player's score.
         More efficient than full recalculation for individual drop additions.
+
+        Seasonal leaderboard keys are prefixed with ``seasonal:`` to keep them
+        separate from main-world rankings.
         """
         if partition is None:
             partition = self._get_partition()
-        
+
+        prefix = "seasonal:" if world_type == "seasonal" else ""
         pipeline = redis_client.client.pipeline(transaction=True)
-        
+
         # Update global leaderboard
-        global_key = f"leaderboard:{partition}"
+        global_key = f"{prefix}leaderboard:{partition}"
         pipeline.zincrby(global_key, value_delta, player_id)
-        
+
         # Update group leaderboards
         if group_ids:
             for group_id in group_ids:
-                group_key = f"leaderboard:{partition}:group:{group_id}"
+                group_key = f"{prefix}leaderboard:{partition}:group:{group_id}"
                 pipeline.zincrby(group_key, value_delta, player_id)
-        
+
         pipeline.execute()
     
-    def _add_drop_incremental(self, player_id: int, drop: Drop) -> bool:
+    def _add_drop_incremental(self, player_id: int, drop, world_type: str = "main") -> bool:
         """Internal method for incremental drop addition"""
         drop_date = self._coerce_drop_datetime(drop.date_added)
         partition = self._get_partition(drop_date)
-        keys = self._get_redis_keys(player_id, partition, drop_date)  # Pass drop_date for daily keys
+        keys = self._get_redis_keys(player_id, partition, drop_date, world_type=world_type)
         
         # Calculate drop values
         total_value = drop.value * drop.quantity


### PR DESCRIPTION
Add 6 new ORM models (seasonal_drops, seasonal_personal_best,
seasonal_collection, seasonal_combat_achievement, seasonal_player_pets,
seasonal_quest_completions) that mirror their main-world counterparts
without mixing data between game modes.

Add get_config_prefix() / SEASONAL_WORLD_TYPE / get_seasonal_model()
helpers to common.py so processors can look up "seasonal_"-prefixed
GroupConfiguration keys (e.g. seasonal_notify_drops, seasonal_minimum_value_to_notify)
enabling per-group opt-in controls for each mode independently.

Each submission processor (drop, pb, clog, ca, pet, quest) now accepts
world_type="main" (default). When world_type=="seasonal" the processor
writes to the seasonal table, queries seasonal_ config keys, skips global
point awards, and includes world_type in notification payloads. A TODO
placeholder marks where award_points_in_leagues group config gating will
be wired in for group-scoped point awards.

redis_updates.add_to_player() accepts world_type and writes player item
totals and leaderboards under a "seasonal:" key namespace so seasonal
lootboards remain completely separate from main-world rankings.

db.create_drop_object() accepts an optional model_class so the same
image-download and flush logic is reused for SeasonalDrop records.

Both webhook dispatchers (bots/webhook_bot.py, api/routes/webhook.py)
now route "seasonal" world_type submissions to the real processors
instead of the previous no-op pass statements, while other unsupported
world types continue to be silently dropped.