### PR TITLE
Implement split GP tracking for group leaderboards (issue #28)

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -527,3 +527,56 @@ class ClanCommands(Extension):
             )
         ]
         await ctx.channel.send(components=player_setup)
+
+    @slash_command(
+        name="toggle-split-tracking",
+        description="Enable or disable split GP tracking for this server's group",
+        default_member_permissions=Permissions.ADMINISTRATOR,
+    )
+    async def toggle_split_tracking_cmd(self, ctx: SlashContext):
+        if not ctx.guild_id:
+            return await ctx.send("Use this command inside your group's Discord server.", ephemeral=True)
+
+        guild = session.query(Guild).filter(Guild.guild_id == str(ctx.guild_id)).first()
+        if not guild or not guild.group_id:
+            return await ctx.send("This server is not linked to a DropTracker group.", ephemeral=True)
+
+        group = session.query(Group).filter(Group.group_id == guild.group_id).first()
+        if not group:
+            return await ctx.send("Group record was not found for this server.", ephemeral=True)
+
+        try:
+            existing = (
+                session.query(GroupConfiguration)
+                .filter(
+                    GroupConfiguration.group_id == guild.group_id,
+                    GroupConfiguration.config_key == "split_gp_tracking",
+                )
+                .first()
+            )
+            if existing:
+                new_value = "0" if existing.config_value == "1" else "1"
+                existing.config_value = new_value
+            else:
+                new_value = "1"
+                session.add(GroupConfiguration(
+                    group_id=guild.group_id,
+                    config_key="split_gp_tracking",
+                    config_value=new_value,
+                ))
+            session.commit()
+        except Exception as e:
+            session.rollback()
+            return await ctx.send(f"Failed to update setting: {e}", ephemeral=True)
+
+        state = "**enabled**" if new_value == "1" else "**disabled**"
+        embed = Embed(
+            title="Split GP Tracking Updated",
+            description=(
+                f"Split GP tracking is now {state} for **{group.group_name}**.\n\n"
+                "When enabled, group leaderboard GP credit is distributed equally among "
+                "all split participants rather than crediting the full value to the drop receiver."
+            ),
+            color=0x2ECC71 if new_value == "1" else 0xE74C3C,
+        )
+        await ctx.send(embed=embed, ephemeral=True)

--- a/data/submissions/drop.py
+++ b/data/submissions/drop.py
@@ -37,6 +37,87 @@ db = DatabaseOperations()
 last_board_updates = {}
 
 
+async def _award_split_gp_credits(session, drop, group, receiver_player_id: int,
+                                   players_included: list, drop_value: int,
+                                   world_type: str = "main") -> None:
+    """
+    For groups with split_gp_tracking enabled, distribute group leaderboard GP
+    credit equally among all split participants (including the receiver).
+
+    - Non-receiver participants get split_value credited via add_split_credit().
+    - The receiver's group leaderboard score is reduced by (full_value - split_value)
+      so their net group credit equals split_value rather than the full drop value.
+    - A DropSplit row is persisted for each non-receiver participant as the
+      source-of-truth for Redis force-rebuilds.
+
+    The global leaderboard and individual player:*:total_loot keys are never
+    modified here.
+    """
+    from db.models.drop_split import DropSplit
+    from db.models import Player, user_group_association
+
+    group_id = group.group_id
+    partition = drop.partition
+
+    # Resolve included player names to Player rows that are in this group
+    valid_participants = []
+    for name in players_included:
+        p = session.query(Player).filter(Player.player_name == name).first()
+        if p is None:
+            continue
+        # Verify the player is a member of this group
+        is_member = (
+            session.query(user_group_association)
+            .filter(
+                user_group_association.c.player_id == p.player_id,
+                user_group_association.c.group_id == group_id,
+            )
+            .first()
+        )
+        if is_member:
+            valid_participants.append(p)
+
+    if not valid_participants:
+        return
+
+    # Total participants = receiver + valid split members
+    total_count = 1 + len(valid_participants)
+    split_value = drop_value // total_count
+
+    # Guard: nothing to do if split equals full value (1-way "split")
+    if split_value >= drop_value:
+        return
+
+    # 1. Adjust receiver's group leaderboard down from full_value to split_value
+    receiver_adjustment = split_value - drop_value  # negative
+    redis_updates.add_split_credit(receiver_player_id, receiver_adjustment, partition, group_id, world_type)
+
+    # 2. Credit each non-receiver participant
+    for p in valid_participants:
+        # Persist the split record (skip if already exists to avoid duplicates)
+        existing = (
+            session.query(DropSplit)
+            .filter(
+                DropSplit.drop_id == drop.drop_id,
+                DropSplit.player_id == p.player_id,
+                DropSplit.group_id == group_id,
+            )
+            .first()
+        )
+        if existing is None:
+            split_row = DropSplit(
+                drop_id=drop.drop_id,
+                player_id=p.player_id,
+                group_id=group_id,
+                split_value=split_value,
+            )
+            session.add(split_row)
+
+        redis_updates.add_split_credit(p.player_id, split_value, partition, group_id, world_type)
+
+    session.flush()
+
+
 def _normalize_incoming_players(players_included):
     """Normalize participant payloads from all drop ingestion paths."""
     if players_included is None:
@@ -267,6 +348,7 @@ async def drop_processor(drop_data, external_session=None, world_type="main"):
                         [
                             f"{config_prefix}minimum_value_to_notify",
                             f"{config_prefix}send_stacks_of_items",
+                            "split_gp_tracking",
                         ]
                     ),
                 )
@@ -361,6 +443,25 @@ async def drop_processor(drop_data, external_session=None, world_type="main"):
                 except Exception as e:
                     print(f"Couldn't perform check against group point awards... e: {e}")
                     pass
+
+            # --- Split GP tracking ---
+            split_tracking_enabled = (
+                group_config_values.get((group_id, "split_gp_tracking")) == "1"
+            )
+            if split_tracking_enabled and players_included and not is_seasonal:
+                try:
+                    await _award_split_gp_credits(
+                        session=session,
+                        drop=drop,
+                        group=group,
+                        receiver_player_id=player_id,
+                        players_included=players_included,
+                        drop_value=drop_value,
+                        world_type=world_type,
+                    )
+                except Exception as e:
+                    print(f"[SplitTracking] Failed to apply split credits for group {group_id}: {e}")
+
             min_value_raw = group_config_values.get((group_id, f"{config_prefix}minimum_value_to_notify"))
             try:
                 min_value_to_notify = int(min_value_raw) if min_value_raw is not None else 2500000

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -47,6 +47,7 @@ from .seasonal_collection_log import SeasonalCollectionLogEntry
 from .seasonal_combat_achievement import SeasonalCombatAchievementEntry
 from .seasonal_pet import SeasonalPlayerPet
 from .seasonal_quest_completion import SeasonalQuestCompletionEntry
+from .drop_split import DropSplit
 
 
 def get_current_partition() -> int:
@@ -120,4 +121,5 @@ __all__ = [
     "SeasonalCombatAchievementEntry",
     "SeasonalPlayerPet",
     "SeasonalQuestCompletionEntry",
+    "DropSplit",
 ]

--- a/db/models/drop_split.py
+++ b/db/models/drop_split.py
@@ -1,0 +1,32 @@
+from sqlalchemy import Column, Integer, ForeignKey, DateTime, event
+from sqlalchemy import func
+from sqlalchemy.orm import relationship
+
+from .base import Base, engine
+
+
+class DropSplit(Base):
+    """
+    Records which players received split GP credit for a given drop within a group.
+
+    One row per non-receiver split participant.  The receiver's credit is
+    implicitly their full drop value minus the adjustment applied to the group
+    leaderboard (tracked via Redis); this table is the source of truth used when
+    force-rebuilding a player's Redis state.
+    """
+    __tablename__ = 'drop_splits'
+    __table_args__ = {'extend_existing': True}
+
+    id          = Column(Integer, primary_key=True, autoincrement=True)
+    drop_id     = Column(Integer, ForeignKey('drops.drop_id'), nullable=False, index=True)
+    player_id   = Column(Integer, ForeignKey('players.player_id'), nullable=False, index=True)
+    group_id    = Column(Integer, ForeignKey('groups.group_id'), nullable=False, index=True)
+    split_value = Column(Integer, nullable=False)
+    date_added  = Column(DateTime, default=func.now())
+
+    player = relationship("Player")
+    drop   = relationship("Drop")
+
+
+# Create the table on first import if it doesn't exist yet.
+DropSplit.__table__.create(engine, checkfirst=True)

--- a/services/entry_modifier.py
+++ b/services/entry_modifier.py
@@ -38,6 +38,7 @@ from sqlalchemy import func as sa_func
 from db.models import (
     Drop,
     Group,
+    GroupConfiguration,
     Guild,
     ItemList,
     NotifiedSubmission,
@@ -47,6 +48,7 @@ from db.models import (
     Session,
     get_current_partition,
 )
+from db.models.drop_split import DropSplit
 from services.redis_updates import RedisLootTracker, loot_tracker, get_player_list_loot_sum
 from utils.redis import redis_client
 
@@ -530,6 +532,55 @@ def _redis_force_update(player_id: int, db):
     tracker.force_update_player(player_id, session_to_use=db)
 
 
+def _group_has_split_tracking(group_id: int, db) -> bool:
+    cfg = (
+        db.query(GroupConfiguration)
+        .filter(
+            GroupConfiguration.group_id == group_id,
+            GroupConfiguration.config_key == "split_gp_tracking",
+            GroupConfiguration.config_value == "1",
+        )
+        .first()
+    )
+    return cfg is not None
+
+
+def _get_split_records(drop_id: int, group_id: int, db):
+    """Return all DropSplit rows for this drop+group."""
+    return (
+        db.query(DropSplit)
+        .filter(DropSplit.drop_id == drop_id, DropSplit.group_id == group_id)
+        .all()
+    )
+
+
+def _reverse_split_credits(drop_id: int, group_id: int, drop_value: int, drop_partition: int, db):
+    """
+    Remove all group leaderboard credits associated with split records for a drop.
+    Call this before deleting/hiding a split drop so leaderboard scores stay correct.
+    Also restores the receiver's score to the full value (undoes the original
+    downward adjustment).
+    """
+    from services.redis_updates import loot_tracker
+
+    split_rows = _get_split_records(drop_id, group_id, db)
+    if not split_rows:
+        return
+
+    # Each participant loses their split credit
+    for row in split_rows:
+        loot_tracker.add_split_credit(row.player_id, -row.split_value, drop_partition, group_id)
+
+    # The receiver's original adjustment was (split_value - drop_value); reverse it
+    split_value = split_rows[0].split_value
+    receiver_restore = drop_value - split_value  # positive — restores receiver
+    if receiver_restore > 0:
+        # We don't have receiver_player_id here directly; get it from the drop
+        drop = db.query(Drop).filter(Drop.drop_id == drop_id).first()
+        if drop:
+            loot_tracker.add_split_credit(drop.player_id, receiver_restore, drop_partition, group_id)
+
+
 async def _try_delete_discord_message(bot, channel_id: str, message_id: str):
     try:
         channel = await bot.fetch_channel(int(channel_id))
@@ -736,18 +787,30 @@ class EntryModifier(Extension):
             # 1. Delete points across all groups
             _delete_points_for_drop_all_groups(drop.drop_id, db)
 
-            # 2. Delete all NotifiedSubmission records for this drop
+            # 2. Reverse split GP credits on group leaderboards for every group
+            #    that has split tracking enabled, then delete the split records.
+            all_split_rows = db.query(DropSplit).filter(DropSplit.drop_id == drop.drop_id).all()
+            affected_split_players = {row.player_id for row in all_split_rows}
+            for row in all_split_rows:
+                if _group_has_split_tracking(row.group_id, db):
+                    drop_value = drop.value * drop.quantity
+                    _reverse_split_credits(drop.drop_id, row.group_id, drop_value, drop.partition, db)
+            db.query(DropSplit).filter(DropSplit.drop_id == drop.drop_id).delete(synchronize_session="fetch")
+
+            # 3. Delete all NotifiedSubmission records for this drop
             db.query(NotifiedSubmission).filter(NotifiedSubmission.drop_id == drop.drop_id).delete(synchronize_session="fetch")
 
-            # 3. Delete the drop itself
+            # 4. Delete the drop itself
             db.query(Drop).filter(Drop.drop_id == drop.drop_id).delete(synchronize_session="fetch")
 
             db.commit()
 
-            # 4. Force update Redis
+            # 5. Force update Redis for receiver and all split participants
             _redis_force_update(player_id, db)
+            for split_player_id in affected_split_players:
+                _redis_force_update(split_player_id, db)
 
-            # 5. Delete the original Discord message
+            # 6. Delete the original Discord message
             await _try_delete_discord_message(self.bot, orig_channel_id, orig_message_id)
 
             await ctx.edit_origin(
@@ -793,6 +856,14 @@ class EntryModifier(Extension):
                 notified.status = "hidden"
                 db.commit()
 
+                # Reverse split GP credits (preserve DropSplit rows for unhide)
+                if _group_has_split_tracking(notified.group_id, db):
+                    drop_value = drop.value * drop.quantity
+                    split_rows = _get_split_records(drop.drop_id, notified.group_id, db)
+                    _reverse_split_credits(drop.drop_id, notified.group_id, drop_value, drop.partition, db)
+                    for row in split_rows:
+                        _redis_force_update(row.player_id, db)
+
                 _redis_force_update(player_id, db)
 
                 hidden_embed = Embed(
@@ -824,6 +895,19 @@ class EntryModifier(Extension):
                     split_names = _get_split_player_names(drop.drop_id, group.group_id, drop.player_id, db)
                     await _re_award_points(drop, group.group_id, split_names or None, db)
                 db.commit()
+
+                # Re-apply split GP credits from preserved DropSplit rows
+                if _group_has_split_tracking(notified.group_id, db):
+                    drop_value = drop.value * drop.quantity
+                    split_rows = _get_split_records(drop.drop_id, notified.group_id, db)
+                    if split_rows:
+                        split_value = split_rows[0].split_value
+                        receiver_adjustment = split_value - drop_value
+                        from services.redis_updates import loot_tracker
+                        loot_tracker.add_split_credit(player_id, receiver_adjustment, drop.partition, notified.group_id)
+                        for row in split_rows:
+                            loot_tracker.add_split_credit(row.player_id, row.split_value, drop.partition, notified.group_id)
+                            _redis_force_update(row.player_id, db)
 
                 _redis_force_update(player_id, db)
 
@@ -967,8 +1051,36 @@ class EntryModifier(Extension):
                 await _re_award_points(drop, group.group_id, split_names or None, db)
             db.commit()
 
-            # 4. Force update Redis
+            # 3b. Recalculate split GP credits for groups with split tracking
+            new_full_value = new_value * drop.quantity
+            affected_split_players: set = set()
+            for group in player_groups:
+                if not _group_has_split_tracking(group.group_id, db):
+                    continue
+                split_rows = _get_split_records(drop.drop_id, group.group_id, db)
+                if not split_rows:
+                    continue
+                old_split_value = split_rows[0].split_value
+                total_count = 1 + len(split_rows)
+                new_split_value = new_full_value // total_count
+                from services.redis_updates import loot_tracker
+                # Adjust each participant's leaderboard score by the delta
+                participant_delta = new_split_value - old_split_value
+                for row in split_rows:
+                    loot_tracker.add_split_credit(row.player_id, participant_delta, drop.partition, group.group_id)
+                    row.split_value = new_split_value
+                    affected_split_players.add(row.player_id)
+                # Adjust receiver: old offset was (old_split_value - old_full_value),
+                # new offset is (new_split_value - new_full_value); apply the net delta
+                old_full_value = old_split_value * total_count
+                receiver_delta = (new_split_value - new_full_value) - (old_split_value - old_full_value)
+                loot_tracker.add_split_credit(drop.player_id, receiver_delta, drop.partition, group.group_id)
+            db.commit()
+
+            # 4. Force update Redis for receiver and all split participants
             _redis_force_update(drop.player_id, db)
+            for sp_id in affected_split_players:
+                _redis_force_update(sp_id, db)
 
             # 5. Rebuild the notification embed so all fields reflect the change
             await _rebuild_and_edit_message(
@@ -1005,19 +1117,76 @@ class EntryModifier(Extension):
             _delete_points_for_drop(drop.drop_id, notified.group_id, db)
             db.commit()
 
-            # 2. Re-award with new split list
-            await _re_award_points(drop, notified.group_id, new_split_names or None, db)
+            # 2. Reverse split GP credits if group has split tracking
+            affected_split_players: set = set()
+            group_id = notified.group_id
+            drop_value = drop.value * drop.quantity
+            if _group_has_split_tracking(group_id, db):
+                old_split_rows = _get_split_records(drop.drop_id, group_id, db)
+                if old_split_rows:
+                    _reverse_split_credits(drop.drop_id, group_id, drop_value, drop.partition, db)
+                    for row in old_split_rows:
+                        affected_split_players.add(row.player_id)
+                    db.query(DropSplit).filter(
+                        DropSplit.drop_id == drop.drop_id,
+                        DropSplit.group_id == group_id,
+                    ).delete(synchronize_session="fetch")
+                    db.commit()
+
+            # 3. Re-award points with new split list
+            await _re_award_points(drop, group_id, new_split_names or None, db)
             notified.edited_by = None
             db.commit()
 
-            # 3. Rebuild the notification embed so all fields reflect the change
+            # 4. Apply new split GP credits for the new participant list
+            if _group_has_split_tracking(group_id, db) and new_split_names:
+                from db.models import Player, user_group_association
+                from services.redis_updates import loot_tracker
+                valid_new = []
+                for name in new_split_names:
+                    p = db.query(Player).filter(Player.player_name == name).first()
+                    if p is None:
+                        continue
+                    is_member = (
+                        db.query(user_group_association)
+                        .filter(
+                            user_group_association.c.player_id == p.player_id,
+                            user_group_association.c.group_id == group_id,
+                        )
+                        .first()
+                    )
+                    if is_member:
+                        valid_new.append(p)
+                if valid_new:
+                    total_count = 1 + len(valid_new)
+                    new_split_value = drop_value // total_count
+                    receiver_adjustment = new_split_value - drop_value
+                    loot_tracker.add_split_credit(drop.player_id, receiver_adjustment, drop.partition, group_id)
+                    for p in valid_new:
+                        split_row = DropSplit(
+                            drop_id=drop.drop_id,
+                            player_id=p.player_id,
+                            group_id=group_id,
+                            split_value=new_split_value,
+                        )
+                        db.add(split_row)
+                        loot_tracker.add_split_credit(p.player_id, new_split_value, drop.partition, group_id)
+                        affected_split_players.add(p.player_id)
+                    db.commit()
+
+            # 5. Force update Redis for receiver and all affected participants
+            _redis_force_update(drop.player_id, db)
+            for sp_id in affected_split_players:
+                _redis_force_update(sp_id, db)
+
+            # 6. Rebuild the notification embed so all fields reflect the change
             split_note = f"Split updated: {', '.join(new_split_names)}" if new_split_names else "Splits removed"
             await _rebuild_and_edit_message(
                 self.bot, drop, data["player"], data["item"], data["npc"], notified, db,
                 history_line=split_note,
             )
 
-            # 4. Show updated overview
+            # 7. Show updated overview
             await _send_overview(ctx, notified_id, db)
         except Exception as e:
             db.rollback()

--- a/services/redis_updates.py
+++ b/services/redis_updates.py
@@ -392,16 +392,67 @@ class RedisLootTracker:
             for daily_partition, drops in daily_drops.items():
                 self._rebuild_daily_data(player_id, daily_partition, drops)
                 print(f"Updated daily data for player {player_id} on {daily_partition}")
+
+            # Re-apply split GP credits earned as a participant in other players' drops.
+            # These are not in the player's own Drop rows, so they must be reconstructed
+            # from drop_splits separately.
+            self._apply_split_credits(player_id, session_to_use)
+
             # Update player's last update timestamp
             player.date_updated = datetime.now()
             session_to_use.commit()
-            
+
             return True
             
         except Exception as e:
             print(f"Force update failed for player {player_id}: {e}")
             return False
     
+    def _apply_split_credits(self, player_id: int, session_to_use) -> None:
+        """
+        After a full Redis rebuild, re-apply group leaderboard credits that come
+        from drop_splits rows (i.e. drops the player participated in but did not
+        receive).  Only rows for groups that currently have split_gp_tracking
+        enabled are processed so that stale rows from before the flag was enabled
+        are silently ignored.
+        """
+        try:
+            from db.models.drop_split import DropSplit
+            from db.models import GroupConfiguration, Drop
+
+            split_rows = (
+                session_to_use.query(DropSplit)
+                .filter(DropSplit.player_id == player_id)
+                .all()
+            )
+            if not split_rows:
+                return
+
+            # Build a set of group_ids that have split_gp_tracking enabled
+            unique_group_ids = {row.group_id for row in split_rows}
+            enabled_configs = (
+                session_to_use.query(GroupConfiguration.group_id)
+                .filter(
+                    GroupConfiguration.group_id.in_(unique_group_ids),
+                    GroupConfiguration.config_key == "split_gp_tracking",
+                    GroupConfiguration.config_value == "1",
+                )
+                .all()
+            )
+            enabled_groups = {row.group_id for row in enabled_configs}
+
+            for row in split_rows:
+                if row.group_id not in enabled_groups:
+                    continue
+                # Determine the partition from the parent drop
+                drop = session_to_use.query(Drop).filter(Drop.drop_id == row.drop_id).first()
+                if not drop or drop.hidden:
+                    continue
+                partition = drop.partition
+                self.add_split_credit(player_id, row.split_value, partition, row.group_id)
+        except Exception as e:
+            print(f"[RedisLootTracker] _apply_split_credits failed for player {player_id}: {e}")
+
     def _clear_player_redis_data(self, player_id: int):
         """Clear all Redis data for a player"""
         # Get all keys for this player
@@ -716,26 +767,42 @@ class RedisLootTracker:
         
         return (int(rank) + 1, total_players)  # Redis ranks are 0-based
     
-    def update_leaderboards(self, player_id: int, total_value: int, 
+    def update_leaderboards(self, player_id: int, total_value: int,
                            partition: Optional[int] = None, group_ids: Optional[List[int]] = None):
         """Update leaderboards for a player"""
         if partition is None:
             partition = self._get_partition()
-        
+
         pipeline = redis_client.client.pipeline(transaction=True)
-        
+
         # Update global leaderboard
         global_key = f"leaderboard:{partition}"
         pipeline.zadd(global_key, {player_id: total_value})
-        
+
         # Update group leaderboards
         if group_ids:
             for group_id in group_ids:
                 group_key = f"leaderboard:{partition}:group:{group_id}"
                 pipeline.zadd(group_key, {player_id: total_value})
                 print(f"Updated group leaderboard {group_id} for player {player_id} with value {total_value:,}")
-        
+
         pipeline.execute()
+
+    def add_split_credit(self, player_id: int, split_value: int, partition: int,
+                         group_id: int, world_type: str = "main") -> None:
+        """
+        Atomically adjust a player's score in a single group leaderboard by split_value.
+
+        Pass a positive delta to credit a split participant, or a negative delta
+        (split_value - full_value) to bring the drop receiver's group score down
+        from the full drop value to their equal share.
+
+        Only the group leaderboard sorted set is touched — global leaderboard and
+        individual player:*:total_loot keys are never modified.
+        """
+        prefix = "seasonal:" if world_type == "seasonal" else ""
+        key = f"{prefix}leaderboard:{partition}:group:{group_id}"
+        redis_client.client.zincrby(key, split_value, player_id)
 
 # Global instance
 loot_tracker = RedisLootTracker()


### PR DESCRIPTION
Groups can now enable split GP tracking via /toggle-split-tracking,
causing group leaderboard credit to be distributed equally among all
split participants instead of crediting the full value to the receiver.

- db/models/drop_split.py: New DropSplit ORM model; auto-creates table
  on first import using checkfirst=True
- db/models/__init__.py: Register DropSplit in module exports
- services/redis_updates.py: Add add_split_credit() for targeted group
  leaderboard adjustments; add _apply_split_credits() called from
  force_update_player() to rebuild split credits after a full Redis wipe
- data/submissions/drop.py: _award_split_gp_credits() helper creates
  DropSplit rows and adjusts group leaderboard scores on drop ingestion
  when split_gp_tracking is enabled for the group
- services/entry_modifier.py: All Modify Entry operations (delete, hide,
  unhide, edit value, modify splits) now propagate split credit changes
  to group leaderboards and force-update affected split participants
- commands/admin.py: /toggle-split-tracking command for group leaders

Global leaderboard and individual player:*:total_loot keys are never
modified; only group leaderboard sorted sets are affected.

https://claude.ai/code/session_01CX1gumZvw34BoY4uyEDfwK